### PR TITLE
added required packages to fix build - puppet & librarian-puppet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ ARG user=jenkins
 
 USER root
 RUN apt-get update && \
-    apt install -y curl php-cli php-mbstring php-xml php-gd php-zip libpng-dev build-essential gcc make git jq unzip php- && \
+    apt install -y curl php-cli php-mbstring php-xml php-gd php-zip libpng-dev build-essential puppet ruby-dev gcc make git jq unzip php- && \
     rm -rf /var/lib/apt/lists/*
+RUN gem install librarian-puppet
 RUN curl -sS https://getcomposer.org/installer -o composer-setup.php
 RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.17
 USER ${user}


### PR DESCRIPTION
In order to fix:

![Screenshot 2020-11-18 at 14 06 57](https://user-images.githubusercontent.com/47026707/99540261-34f9de80-29a7-11eb-92ec-525bea9d3462.png)

I have added some packages to the Dockerfile - tested locally:

`jenkins@bbd353041f9e:~$ librarian-puppet version
librarian-puppet v3.0.0`

`jenkins@bbd353041f9e:~$ puppet --version
5.5.10`